### PR TITLE
Fix the travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,16 @@ compiler:
     - gcc
 
 before_install:
+    - vmstat 1 1
+    # Terminate if in the bad memory condition
+    - python -c "import sys;sys.exit(int(open('/proc/meminfo').read().split('Cached:')[1].strip().split()[0])<32)"
     - sudo apt-get install npm
     - "mongo --eval 'db.runCommand({setParameter: 1, textSearchEnabled: true})' admin"
 
 install:
     - pwd
     - echo $PYTHONPATH
-    - sudo pip install tangelo
+    - sudo pip install tangelo==0.7.0
     - sudo pip install pep8 coverage
     - npm install -g grunt grunt-cli
 

--- a/test/base.py
+++ b/test/base.py
@@ -64,8 +64,8 @@ def startServer():
     print(" ".join(tangeloArgs))
     process = subprocess.Popen(
         tangeloArgs,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT
+        stdout=sys.stdout.fileno(),
+        stderr=sys.stdout.fileno()
     )
 
     # Give it time to spin up


### PR DESCRIPTION
Primarily, fix the tangelo version to 0.7.0 until we are ready to update the tests.

Change how tangelo is called so that we can log error output.

Add vmstat to tell if travis is having a memory issue.  Added a quick test that errors out the travis build before doing much if the memory issue is happening.