### PR TITLE
Heatmap rows and columns now match the table view

### DIFF
--- a/app/src/plugins/interactiveheatmap.js
+++ b/app/src/plugins/interactiveheatmap.js
@@ -20,6 +20,7 @@
             var heatmap = d3.chart.heatmap(),
                 data = this.options.data.rows,
                 columnHeaders = this.options.data.fields;
+
             d3.select("#heatmap")
                 .datum(data)
                 .call(heatmap, columnHeaders);

--- a/lib/js/d3.interactiveheatmap.js
+++ b/lib/js/d3.interactiveheatmap.js
@@ -11,7 +11,7 @@ d3.chart = d3.chart || {};
  */
 
 d3.chart.heatmap = function(options) {
-  function createHeatmap(selection, rowLabelsData) {
+  function createHeatmap(selection, columnHeaders) {
     selection.each(function(data) {
 
       var rowSortOrder = false;
@@ -24,47 +24,41 @@ d3.chart.heatmap = function(options) {
       var legendWidth = 200;
 
       //==================================================
-
       // Note: If the first column header is empty then assume the first column
-      //       is labels. Not the best method ever but will work for now.
-      var useColumnLabels = (rowLabelsData[0] == "");
+      //       is row labels. Not the best method ever but will work for now.
+      var useRowLabels = (columnHeaders[0] == "");
+
+      var dataset = [];
+      var rowHeaders = [];
 
       // Parse data
-      var dataset = [];
-      // Note: In the example .csv file each row is a patient and each column is a measurement...
-      //       On the heatmap, want to display patients in COLUMNS and data in ROWS ?
-      rowLabelsData.forEach(function(d, i) {
+      data.forEach(function(d, i) {
         dataset[i] = [];
-      });
-      data.forEach(function(d){
-        // Convert all values from strings to numbers...
-        rowLabelsData.forEach(function(key, i) {
+        columnHeaders.forEach(function(column) {
           var val;
-          if (useColumnLabels && i == 0) {
-            val = d[key];
+          if (useRowLabels && column == "") {
+            val = d[column];
+            rowHeaders.push(val);
           }
           else {
-            val = (d[key] == "") ? NaN : +d[key];
+            // Convert all values from strings to numbers...
+            val = (d[column] == "") ? NaN : +d[column];
+            dataset[i].push(val);
           }
-          dataset[i].push(val);
         });
       });
 
       //==================================================
 
-      var columnLabelsData;
+      var numberOfColumns = columnHeaders.length;
+      var numberOfRows = dataset.length;
 
-      if (useColumnLabels) {
+      if (useRowLabels) {
         // Note: array.shift() removes and returns the first element of an array
-        columnLabelsData = dataset.shift();
-        rowLabelsData.shift();  // Need to update the row labels too or will be off by one...
+        columnHeaders.shift();
       }
-
-      var numberOfRows = rowLabelsData.length;
-      var numberOfColumns = dataset[0].length;
-
-      if (!useColumnLabels) {
-        columnLabelsData = d3.range(numberOfColumns);
+      else {
+        rowHeaders = d3.range(numberOfRows);
       }
 
       // Find min and max
@@ -101,24 +95,28 @@ d3.chart.heatmap = function(options) {
 
       var svg = selection.append("svg");
 
-      margin.left += getMaxWidth(rowLabelsData);
+      margin.left += getMaxWidth(rowHeaders);
 
       // Use the number of cells to determine the size and spacing
       var n = Math.max(numberOfColumns, numberOfRows);
       var cellSize = Math.floor(1600 / n);      // TODO: Should cells be square?
-      if (cellSize < 10)
+      if (cellSize < 10) {
         cellSize = 10;
+      }
+      else if (cellSize > 25) {
+        cellSize = 25;
+      }
 
       var width = cellSize * numberOfColumns;
       var height = cellSize * numberOfRows;
 
-      var columnLabelSize = getMaxWidth(columnLabelsData);
+      var columnLabelSize = getMaxWidth(columnHeaders);
       if (columnLabelSize < 30) { columnLabelSize = 30; }
       var heatmapY = margin.top + legendHeight + legendMargin.top + legendMargin.bottom + columnLabelSize;
 
       svg.attr("width", width + margin.left + margin.right)
         .attr("height", height + heatmapY)
-        .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+        .attr("transform", "translate(" + 0 + "," + margin.top + ")");
 
       // TODO: If the heatmap height is not set here, then it gets smaller (?) as
       //       the number of columns (patients) increases ... The width seems to be okay.
@@ -129,7 +127,7 @@ d3.chart.heatmap = function(options) {
       createLegend(svg);
 
       svg = svg.append("g")
-        .attr("transform", "translate(" + 0 + "," + heatmapY + ")");
+        .attr("transform", "translate(" + margin.left  + "," + heatmapY + ")");
 
       // Create a color scale
       var colors = ["#0000FF", "#FFFF00"] // blue ---> yellow
@@ -192,7 +190,7 @@ d3.chart.heatmap = function(options) {
       var rowLabels = svg.append("g")
         .attr("class", "rowLabels")
         .selectAll(".rowLabel")
-        .data(rowLabelsData)
+        .data(rowHeaders)
         .enter().append("text")
         .text(function(d) {
           return d;
@@ -224,7 +222,7 @@ d3.chart.heatmap = function(options) {
       var colLabels = svg.append("g")
         .attr("class", "colLabels")
         .selectAll(".colLabel")
-        .data(columnLabelsData)
+        .data(columnHeaders)
         .enter().append("text")
         .text(function(d) { return d; })
         .attr("x", 0)
@@ -306,7 +304,7 @@ d3.chart.heatmap = function(options) {
 
         var xAxis = svg.append("g")
           .attr("class", "x axis")
-          .attr("transform", "translate(0," + legendHeight + ")")
+          .attr("transform", "translate(" + "0" + "," + legendHeight + ")")
           .call(tickmarks);
 
         var bbox = xAxis.node().getBBox();  // Get x-axis dimensions


### PR DESCRIPTION
Also fixed heatmap layout in Chrome (labels were cut off).

<!---
@huboard:{"order":62.875,"milestone_order":90,"custom_state":""}
-->
