### PR TITLE
support jsonlines extension for the corresponding type

### DIFF
--- a/app/src/util.js
+++ b/app/src/util.js
@@ -14,6 +14,7 @@
             png: {type: 'image', format: 'png'},
             rds: {type: 'r', format: 'serialized'},
             'objectlist-json': {type: 'table', format: 'objectlist.json'},
+            jsonlines: {type: 'table', format: 'jsonlines'},
             'rows-json': {type: 'table', format: 'rows.json'},
             'number-json': {type: 'number', format: 'json'}
         },

--- a/app/src/views/DatasetManagementView.js
+++ b/app/src/views/DatasetManagementView.js
@@ -4,7 +4,7 @@
     // The view for managing data saving and downloading
     flow.DatasetManagementView = Backbone.View.extend({
         saveFormats: {
-            table: ['csv', 'tsv', 'rows.json', 'objectlist.json', 'vtktable.serialized'],
+            table: ['csv', 'tsv', 'rows.json', 'objectlist.json', 'vtktable.serialized', 'jsonlines'],
             tree: ['nested.json', 'nexus', 'newick', 'vtktree.serialized'],
             image: ['png'],
             r: ['serialized'],
@@ -17,6 +17,7 @@
             "table:tsv": "tsv",
             "table:rows.json": "rows-json",
             "table:objectlist.json": "objectlist-json",
+            "table:jsonlines": "jsonlines",
             "table:vtktable.serialized": "vtk",
             "tree:nested.json": "nested-json",
             "tree:nexus": "nex",


### PR DESCRIPTION
"jsonlines" is a common format for mongo dumps where there is one JSON object per line that is supported in Romanesco. This exposes that type to the web interface with a specific file extension interpreted as that format.