### PR TITLE
Make easy-mode installation idempotent

### DIFF
--- a/devops/ansible/easymode-setup.py
+++ b/devops/ansible/easymode-setup.py
@@ -8,17 +8,6 @@ if len(sys.argv) < 2:
     sys.exit(1)
 arborWebAppsPath = sys.argv[1]
 
-# Read our analyses into Python dictionaries.
-ACR = {}
-with open ("%s/ancestral-state/aceArbor.json" % arborWebAppsPath, "r") as acrFile:
-    acrStr = acrFile.read()
-ACR['analysis'] = json.loads(acrStr)
-
-PGS = {}
-with open ("%s/phylogenetic-signal/Phylogenetic_signal.json" % arborWebAppsPath, "r") as pgsFile:
-    pgsStr = pgsFile.read()
-PGS['analysis'] = json.loads(pgsStr)
-
 # Get the ID for our Analyses folder.
 c = GirderClient('localhost', 9000)
 c.authenticate('girder', 'girder')
@@ -28,8 +17,43 @@ folderSearch = c.sendRestRequest('GET', 'resource/search', {
 })
 folderId = folderSearch['folder'][0]['_id']
 
-# Upload our analyses to girder.
-itemId = c.createItem(folderId, 'aceArbor', 'Ancestral state reconstruction')
-c.addMetaDataToItem(itemId, ACR)
-itemId = c.createItem(folderId, 'Phylogenetic signal', 'Phylogenetic signal')
-c.addMetaDataToItem(itemId, PGS)
+# Check if these analyses already exist.  If so, we won't re-upload them.
+uploadACR = False
+uploadPGS = False
+
+searchACR = c.sendRestRequest('GET', 'resource/search', {
+    'q': 'aceArbor',
+    'types': '["item"]'
+})
+if len(searchACR['item']) == 0:
+  uploadACR = True
+
+searchPGS = c.sendRestRequest('GET', 'resource/search', {
+    'q': 'Phylogenetic signal',
+    'types': '["item"]'
+})
+if len(searchPGS['item']) == 0:
+  uploadPGS = True
+
+# Read our analyses into Python dictionaries and upload them to girder.
+if uploadACR:
+  ACR = {}
+  with open ("%s/ancestral-state/aceArbor.json" % arborWebAppsPath, "r") as acrFile:
+      acrStr = acrFile.read()
+  ACR['analysis'] = json.loads(acrStr)
+  itemId = c.createItem(folderId, 'aceArbor', 'Ancestral state reconstruction')
+  c.addMetaDataToItem(itemId, ACR)
+  print "aceArbor successfully uploaded"
+else:
+  print "aceArbor already exists"
+
+if uploadPGS:
+  PGS = {}
+  with open ("%s/phylogenetic-signal/Phylogenetic_signal.json" % arborWebAppsPath, "r") as pgsFile:
+      pgsStr = pgsFile.read()
+  PGS['analysis'] = json.loads(pgsStr)
+  itemId = c.createItem(folderId, 'Phylogenetic signal', 'Phylogenetic signal')
+  c.addMetaDataToItem(itemId, PGS)
+  print "Phylogenetic signal successfully uploaded"
+else:
+  print "Phylogenetic signal already exists"

--- a/devops/ansible/playbook.yml
+++ b/devops/ansible/playbook.yml
@@ -171,10 +171,10 @@
     command: python easymode-setup.py /vagrant/ArborWebApps chdir=/vagrant/devops/ansible
 
   - name: tangelo-hub | create ancestral-state symbolic link
-    command: ln -s /vagrant/ArborWebApps/ancestral-state chdir=/vagrant/app
+    file: src=/vagrant/ArborWebApps/ancestral-state dest=/vagrant/app/ancestral-state state=link
 
   - name: tangelo-hub | create phylogenetic-signal symbolic link
-    command: ln -s /vagrant/ArborWebApps/phylogenetic-signal chdir=/vagrant/app
+    file: src=/vagrant/ArborWebApps/phylogenetic-signal dest=/vagrant/app/phylogenetic-signal state=link
 
   - name: apache | enable http proxy
     command: a2enmod proxy_http


### PR DESCRIPTION
This commit makes it so that we can run "vagrant provision"
multiple times without creating extra copies of our easy-mode
analyses.  It also fixes the way we create symbolic links into
our easy-mode apps.